### PR TITLE
Clarify a custom-built machine HCL entry

### DIFF
--- a/System_manufacturer-System_Product_Name-20171110-213615.yml
+++ b/System_manufacturer-System_Product_Name-20171110-213615.yml
@@ -14,9 +14,9 @@ tpm:
 remap:
   'no'
 brand: |
-  System manufacturer
+  N/A
 model: |
-  System Product Name
+  Custom built machine
 bios: |
   1001
 cpu: |


### PR DESCRIPTION
This displaying as "N/A Custom built machine" on the website isn't exactly ideal, but it's still better than "System manufacturer System Product Name" which is what was there before...