### PR TITLE
Update Oryx Pro data

### DIFF
--- a/System76-Oryx_Pro-20190128-114149.yml
+++ b/System76-Oryx_Pro-20190128-114149.yml
@@ -10,7 +10,8 @@ iommu:
 slat:
   'yes'
 tpm:
-  'unknown'
+  status: 'no'
+  message: 'TPM 2.0 only'
 remap:
   'yes'
 brand: |

--- a/System76-Oryx_Pro-20190128-114149.yml
+++ b/System76-Oryx_Pro-20190128-114149.yml
@@ -53,7 +53,7 @@ versions:
   kernel: |
     4.14.74-1
   remark: |
-    Audio not working
+    Audio may require installing <code>kernel-next</code>, keyboard LED control doesn't work
   credit: |
     Shahin Azad
   link: |


### PR DESCRIPTION
Not entirely sure if it's kosher to submit changes to someone else's HCL report, but I own the laptop in question and can add some information about it.

The keyboard LEDs not being controllable can be solved by installing the System76 DKMS package; see QubesOS/qubes-issues#5621 - I didn't link to my packaging since I wasn't sure if that would be okay to do on the official HCL, but I'm happy to add a link if it would be helpful.

Per the second commit message, this PR depends on QubesOS/qubesos.github.io#128.